### PR TITLE
pritnWidth set to 150 to match with the eslint rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 module.exports = {
-    printWidth: 200,
+    printWidth: 150,
     tabWidth: 2,
     useTabs: false,
     semi: true,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@progresskinvey/prettier-config",
   "license": "Apache-2.0",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Prettier config for Kinvey",
   "main": "index.js",
   "scripts": {},


### PR DESCRIPTION
Github displays the code in a limited space. When the line length is more than ~150 symbols the code reviews become harder, because part of the code is not visible on the screen.
![Screenshot 2022-02-09 at 14 07 22](https://user-images.githubusercontent.com/3524687/153198047-12722b97-85a7-4960-9f07-973bcb785885.png)
